### PR TITLE
Feeding back some settings to operate on our TUM hydro pipelines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,12 @@
 name: mglet-build
 
 on:
-  pull_request:
-    branches: [ master ]
+  push:
+    branches: 
+      - 'michael/**'
+      - 'lukas/**'
+      - 'yoshi/**'
+      - 'simon/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -11,17 +15,17 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 15
 
     strategy:
       matrix:
-        image: ["intel-impi-image:sha-57f558e", "gnu-ompi-image:sha-57f558e"]
-        build: ["release", "debug"]
+        image: ["build-base-image:master"]
+        build: ["debug"]
         prec: ["Single", "Double"]
       fail-fast: false
 
     container:
-      image: ghcr.io/kmturbulenz/${{ matrix.image }}
+      image: ghcr.io/tum-hydromechanics/${{ matrix.image }}
       options: "--cap-add=SYS_PTRACE --shm-size=4gb"
 
     steps:
@@ -29,22 +33,17 @@ jobs:
 
     - name: Build MGLET
       run: |
-        source /opt/bashrc || true
+        source /root/.bashrc || true
         mkdir build
         cd build
-        TOOLCHAIN=${{ contains(matrix.image, 'gnu') && 'gnu' || 'intel' }}
+        TOOLCHAIN=${{ contains(matrix.image, 'base') && 'gnu' || 'intel' }}
         cmake -GNinja --preset=${TOOLCHAIN}-${{ matrix.build }} -DMGLET_REAL64="${{ matrix.prec == 'Double' && 'ON' || 'OFF' }}" ..
         ninja
         ls -R
 
-    - name: Install 'gdb' and 'pidof'
-      run: |
-        source /opt/bashrc || true
-        yum ${{ contains(matrix.image, 'intel') && '--disablerepo=oneAPI' || '' }} --disablerepo=ius -y install gdb sysvinit-tools
-
     - name: Run testcases
       run: |
-        source /opt/bashrc || true
+        source /root/.bashrc || true
         cd build
         export OMPI_ALLOW_RUN_AS_ROOT=1
         export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
@@ -59,5 +58,7 @@ jobs:
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "Total test time: $DURATION sec" >> $GITHUB_STEP_SUMMARY
         CPUNAME=$(lscpu | grep 'Model name' | cut -f 2 -d ":" | awk '{$1=$1}1')
+
+        
         echo "CPU model name: $CPUNAME" >> $GITHUB_STEP_SUMMARY
         exit $EXITCODE


### PR DESCRIPTION
Dear all,

to configure our repository and to activate the TUM-specific test pipeline, some adaptations to the "build.yml" are suggested.

The overall concept is:

- we can manage our own docker image (ubuntu2204, gcc+gfortran), where versions of HDF5, OpenMPI, CMake can be set according to our needs.  Please, check [tum-mglet-base-image](https://github.com/tum-hydromechanics/tum-mglet-base-image) for reference. 
- Images with the Intel compilers become too large to be hosted for free on any platform known to me. Intel license constraints forbid KMT to open their images to us.
- the image can be updated be changes to the Docker file in [tum-mglet-base-image](https://github.com/tum-hydromechanics/tum-mglet-base-image). At "push", the image is built on the GitHub runners and pushed to GHCR (container repository).
- a reduced building and test pipeline with only two different builds is suggested to be launched at pushes to personal development branches.

Please, let me know if that makes a reasonable basis.

Bets regards,

Simon
