### PR TITLE
Adding linter tool (TUM)

### DIFF
--- a/.github/workflows/tum_build.yml
+++ b/.github/workflows/tum_build.yml
@@ -3,6 +3,7 @@ name: tum-mglet-build
 on:
   push:
     branches:
+      - 'master'
       - 'michael/**'
       - 'lukas/**'
       - 'yoshi/**'

--- a/.github/workflows/tum_lint.yml
+++ b/.github/workflows/tum_lint.yml
@@ -1,0 +1,38 @@
+name: tum_lint
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'michael/**'
+      - 'lukas/**'
+      - 'yoshi/**'
+      - 'simon/**'
+      - 'philip/**'
+      - 'julius/**'
+      - 'javier/**'
+      - 'feyza/**'
+      - 'jakob/**'
+      - 'mohammadreza/**'
+      - 'particle/**'
+      - 'softwarelab/**'
+      - 'catalyst/**'
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  fortran-lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install whatthepatch
+      run: |
+        python3 -m pip install whatthepatch
+
+    - name: Lint
+      run: |
+        git fetch origin master
+        git diff origin/master..HEAD | ./ci/lint-fortran.py --stdin


### PR DESCRIPTION
Dear all,

KMT has been experimenting with a linting tool, that checks certain formatting criteria of the newly committed code lines (e.g. line length, white spaces, upper and lower cases of Fortran syntax). Please, feel free to check the rules yourselves in [this file](https://raw.githubusercontent.com/tum-hydromechanics/tum-mglet-base/64e49579b9d079f9cb885fb82899013d8abd2aa6/ci/lint-fortran.py). 

According to my understanding of the rule set and my experience so far, those rules comply well with what we had once defined as a coding standard.

With your permission, I am merging this PR, which will then activate the linter and enforce the code formatting rules. Please, give me your feedback.

Best regards,

Simon
